### PR TITLE
catch errors, use neg #'s, only select px

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -17,51 +17,55 @@ function activate(context) {
   // The command has been defined in the package.json file
   // Now provide the implementation of the command with  registerCommand
   // The commandId parameter must match the command field in package.json
-  let disposable = vscode.commands.registerCommand('extension.pxToThesisUnit', function () {
+  let disposable = vscode.commands.registerCommand('extension.pxToThesisUnit', () => {
     // The code you place here will be executed every time your command is executed
     const editor = vscode.window.activeTextEditor;
-    // Display a message box to the user
-    // const selection = editor.document.getText().match('[0-9]+px')
-    const position = editor.document.getWordRangeAtPosition(editor.selection.active)
-    const start = position.start
-    const end = position.end
-    const selection = new vscode.Selection(start.line, start.character, end.line, end.character)
-    const selectTmp = editor.document.getText(selection)
-    // const selection = editor.document.getText(range)
-    let n;
-    if (!selection) {
+    const regex = /^-?\d*px/
+    const position = editor.document.getWordRangeAtPosition(editor.selection.active, regex)
+    let selection;
+    let selectTmp;
+    if (!position) {
       vscode.window.showInformationMessage(`Not a a valid selection`);
+      return
     } else {
+      const start = position.start
+      const end = position.end
+      selection = new vscode.Selection(start.line, start.character, end.line, end.character)
+      selectTmp = editor.document.getText(selection)
+
+      let n;
+
       n = Number(selectTmp.slice(0, -2))
-      if (typeof n === "number")
+      if (typeof n === "number") {
         if (n % 8 === 0) {
           n = `s(${n / 8})`
-
+        } else if ((n <= Math.abs(20)) && n % 4 === 0) {
+          n = `s(${n / 8})`
         } else {
           let num = n / 16
           n = `${+num.toFixed(3)}rem`
         }
+      }
       editor.edit(edit => {
         edit.replace(selection, n)
       })
     }
 
   });
-  disposable = vscode.commands.registerCommand('extension.pxToRem', function () {
+  disposable = vscode.commands.registerCommand('extension.pxToRem', () => {
     // The code you place here will be executed every time your command is executed
     const editor = vscode.window.activeTextEditor;
-    // Display a message box to the user
-    // const selection = editor.document.getText().match('[0-9]+px')
-    const position = editor.document.getWordRangeAtPosition(editor.selection.active)
-    const start = position.start
-    const end = position.end
-    const selection = new vscode.Selection(start.line, start.character, end.line, end.character)
-    const selectTmp = editor.document.getText(selection)
-    // const selection = editor.document.getText(range)
-    let n;
-    if (!selection) {
+    const regex = /^-?\d*px/
+    const position = editor.document.getWordRangeAtPosition(editor.selection.active, regex)
+
+    if (!position) {
       vscode.window.showInformationMessage(`Not a a valid selection`);
     } else {
+      const start = position.start
+      const end = position.end
+      const selection = new vscode.Selection(start.line, start.character, end.line, end.character)
+      const selectTmp = editor.document.getText(selection)
+      let n;
       n = Number(selectTmp.slice(0, -2))
 
       let num = n / 16
@@ -76,6 +80,7 @@ function activate(context) {
   context.subscriptions.push(disposable);
 }
 exports.activate = activate;
+
 
 // this method is called when your extension is deactivated
 function deactivate() { }

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "thesis-unit-converter",
 	"displayName": "thesis-unit-converter",
 	"description": "Convert px to thesis units or rem",
-	"version": "0.0.3",
+	"version": "0.1.0",
 	"publisher": "v-toro",
 	"engines": {
 		"vscode": "^1.43.0"

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "thesis-unit-converter",
 	"displayName": "thesis-unit-converter",
 	"description": "Convert px to thesis units or rem",
-	"version": "0.0.2",
+	"version": "0.0.3",
 	"publisher": "v-toro",
 	"engines": {
 		"vscode": "^1.43.0"
@@ -22,6 +22,10 @@
 		"commands": [
 			{
 				"command": "extension.pxToThesisUnit",
+				"title": "thesis converter"
+			},
+			{
+				"command": "extension.pxToRem",
 				"title": "thesis converter"
 			}
 		],


### PR DESCRIPTION
Display errors when a valid selection is not made. Also updated to work with `s()` decimals and negative numbers. Also added regex to selection to make sure that only valid pixel values are selected.